### PR TITLE
fix: BleMtuSizeException on iOS

### DIFF
--- a/mtrust_urp_ble_strategy/lib/src/ble_strategy.dart
+++ b/mtrust_urp_ble_strategy/lib/src/ble_strategy.dart
@@ -233,7 +233,7 @@ class UrpBleStrategy extends ConnectionStrategy {
       await device.connect(
           timeout: const Duration(seconds: 5), autoConnect: false);
 
-      if(device.mtuNow < 512) {
+      if(Platform.isAndroid && device.mtuNow < 512) {
         throw BleMtuSizeException('MTU size is too small: ${device.mtuNow}. MTU size must be at least 512 bytes.');
       }
 

--- a/mtrust_urp_ble_strategy/pubspec.yaml
+++ b/mtrust_urp_ble_strategy/pubspec.yaml
@@ -9,7 +9,8 @@ dependencies:
     sdk: flutter
   freezed_annotation: ^2.0.3
   provider: ^6.0.2
-  mtrust_urp_core: ^9.1.0-11
+  mtrust_urp_core: 
+    path: ../mtrust_urp_core
   flutter_blue_plus: ^1.32.11
   json_annotation: ^4.8.1
   collection: ^1.18.0
@@ -20,3 +21,4 @@ dev_dependencies:
 repository: https://github.com/emdgroup/mtrust-urp
 flutter: 
   uses-material-design: false
+publish_to: none

--- a/mtrust_urp_core/pubspec.yaml
+++ b/mtrust_urp_core/pubspec.yaml
@@ -23,3 +23,4 @@ flutter:
   uses-material-design: true
   assets: 
     - assets/images/
+publish_to: none

--- a/mtrust_urp_ui/example/pubspec.yaml
+++ b/mtrust_urp_ui/example/pubspec.yaml
@@ -8,12 +8,16 @@ dependencies:
   flutter: 
     sdk: flutter
   liquid_flutter: ^22.0.1
-  mtrust_urp_core: ^9.1.0-11
-  mtrust_urp_ui: ^9.1.0-11
-  mtrust_urp_virtual_strategy: ^9.1.0-11
+  mtrust_urp_core: 
+    path: ../../mtrust_urp_core
+  mtrust_urp_ui: 
+    path: ../../mtrust_urp_ui
+  mtrust_urp_virtual_strategy: 
+    path: ../../mtrust_urp_virtual_strategy
 dev_dependencies: 
   flutter_test: 
     sdk: flutter
   flutter_lints: ^5.0.0
 flutter: 
   uses-material-design: true
+publish_to: none

--- a/mtrust_urp_ui/pubspec.yaml
+++ b/mtrust_urp_ui/pubspec.yaml
@@ -10,7 +10,8 @@ dependencies:
   flutter_localizations: 
     sdk: flutter
   mtrust_urp_types: ^6.2.0
-  mtrust_urp_core: ^9.1.0-11
+  mtrust_urp_core: 
+    path: ../mtrust_urp_core
   intl: 0.20.2
   liquid_flutter: ^22.0.4
   shared_preferences: ^2.3.5
@@ -18,7 +19,8 @@ dev_dependencies:
   flutter_test: 
     sdk: flutter
   flutter_lints: ^4.0.0
-  mtrust_urp_virtual_strategy: ^9.1.0-11
+  mtrust_urp_virtual_strategy: 
+    path: ../mtrust_urp_virtual_strategy
   golden_toolkit: ^0.15.0
   mocktail: ^1.0.4
 repository: https://github.com/emdgroup/mtrust-urp
@@ -29,3 +31,4 @@ flutter:
     - assets/sec_reader.png
     - assets/imp_reader.png
     - assets/sec_led.png
+publish_to: none

--- a/mtrust_urp_usb_strategy/pubspec.yaml
+++ b/mtrust_urp_usb_strategy/pubspec.yaml
@@ -7,7 +7,8 @@ description: USB Connection Strategy for URP
 dependencies: 
   flutter: 
     sdk: flutter
-  mtrust_urp_core: ^9.1.0-11
+  mtrust_urp_core: 
+    path: ../mtrust_urp_core
   flutter_libserialport: ^0.4.0
 dev_dependencies: 
   flutter_test: 
@@ -15,3 +16,4 @@ dev_dependencies:
 repository: https://github.com/emdgroup/mtrust-urp
 flutter: 
   uses-material-design: false
+publish_to: none

--- a/mtrust_urp_virtual_strategy/pubspec.yaml
+++ b/mtrust_urp_virtual_strategy/pubspec.yaml
@@ -9,7 +9,8 @@ dependencies:
     sdk: flutter
   freezed_annotation: ^2.0.3
   provider: ^6.0.2
-  mtrust_urp_core: ^9.1.0-11
+  mtrust_urp_core: 
+    path: ../mtrust_urp_core
   json_annotation: ^4.8.1
   collection: ^1.18.0
   async: ^2.11.0
@@ -19,3 +20,4 @@ dev_dependencies:
 repository: https://github.com/emdgroup/mtrust-urp
 flutter: 
   uses-material-design: false
+publish_to: none

--- a/mtrust_urp_wifi_strategy/pubspec.yaml
+++ b/mtrust_urp_wifi_strategy/pubspec.yaml
@@ -8,10 +8,12 @@ dependencies:
   flutter: 
     sdk: flutter
   web_socket_channel: ^2.2.0
-  mtrust_urp_core: ^9.1.0-11
+  mtrust_urp_core: 
+    path: ../mtrust_urp_core
 dev_dependencies: 
   flutter_test: 
     sdk: flutter
 repository: https://github.com/emdgroup/mtrust-urp
 flutter: 
   uses-material-design: false
+publish_to: none


### PR DESCRIPTION
BleMtuSizeException on iOS caused by default mtu size of 23 being reported by device.mtuNow
merckgroup/mtrust-docs#191

# Summary

- mtuSize Check on Android

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [ ] Included tests (or is not applicable).
- [ ] Updated documentation (or is not applicable).