### PR TITLE
fix: revert mtu size check as its causing issues on iOS

### DIFF
--- a/mtrust_urp_ble_strategy/lib/src/ble_strategy.dart
+++ b/mtrust_urp_ble_strategy/lib/src/ble_strategy.dart
@@ -233,9 +233,9 @@ class UrpBleStrategy extends ConnectionStrategy {
       await device.connect(
           timeout: const Duration(seconds: 5), autoConnect: false);
 
-      if(device.mtuNow < 512) {
-        throw BleMtuSizeException('MTU size is too small: ${device.mtuNow}. MTU size must be at least 512 bytes.');
-      }
+      // if(device.mtuNow < 512) {
+      //   throw BleMtuSizeException('MTU size is too small: ${device.mtuNow}. MTU size must be at least 512 bytes.');
+      // }
 
       _deviceSubscription = device.connectionState.listen(_deviceStateChanged);
 


### PR DESCRIPTION
# Summary

- Revert checking the MTU size and throwing exception as it's causing issues on iOS / macOS.

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [ ] Included tests (or is not applicable).
- [ ] Updated documentation (or is not applicable).