### PR TITLE
fix: increase MTU size for Android to 515 (512 bytes data + 3 bytes h…

### DIFF
--- a/mtrust_urp_ble_strategy/lib/src/ble_strategy.dart
+++ b/mtrust_urp_ble_strategy/lib/src/ble_strategy.dart
@@ -231,11 +231,10 @@ class UrpBleStrategy extends ConnectionStrategy {
       urpLogger.d("Trying to connect to device...");
 
       await device.connect(
-          timeout: const Duration(seconds: 5), autoConnect: false);
-
-      if(device.mtuNow < 512) {
-        throw BleMtuSizeException('MTU size is too small: ${device.mtuNow}. MTU size must be at least 512 bytes.');
-      }
+        timeout: const Duration(seconds: 5), 
+        autoConnect: false,
+        mtu: 515, // Android only: Set the MTU size to 515 bytes (512 + 3 for the header, required on some android devices)
+      );
 
       _deviceSubscription = device.connectionState.listen(_deviceStateChanged);
 


### PR DESCRIPTION
…eader, as required for some devices)

# Summary

- Increase of MTU size for Android to 515 bytes (ensuring 512 bytes for data + 3 bytes for header)

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [ ] Included tests (or is not applicable).
- [ ] Updated documentation (or is not applicable).