### PR TITLE
feat!: add device log and restructure core commands

### DIFF
--- a/mtrust_urp_ble_strategy/lib/src/ble_strategy.dart
+++ b/mtrust_urp_ble_strategy/lib/src/ble_strategy.dart
@@ -231,9 +231,10 @@ class UrpBleStrategy extends ConnectionStrategy {
       urpLogger.d("Trying to connect to device...");
 
       await device.connect(
-        timeout: const Duration(seconds: 5), 
+        timeout: const Duration(seconds: 5),
         autoConnect: false,
-        mtu: 515, // Android only: Set the MTU size to 515 bytes (512 + 3 for the header, required on some android devices)
+        mtu:
+            515, // Android only: Set the MTU size to 515 bytes (512 + 3 for the header, required on some android devices)
       );
 
       _deviceSubscription = device.connectionState.listen(_deviceStateChanged);
@@ -244,7 +245,7 @@ class UrpBleStrategy extends ConnectionStrategy {
     } catch (e) {
       print(e);
       disconnectDevice();
-      if(e is BleMtuSizeException) {
+      if (e is BleMtuSizeException) {
         rethrow;
       }
     }

--- a/mtrust_urp_ble_strategy/lib/src/ble_strategy.dart
+++ b/mtrust_urp_ble_strategy/lib/src/ble_strategy.dart
@@ -374,7 +374,7 @@ class UrpBleStrategy extends ConnectionStrategy {
     // Wait for the adapter to be ready if needed.
     // This is especially important on iOS/macOS where the service needs longer to initialize.
     // See FlutterBluePlus documentation for more details.
-    if (Platform.isIOS || Platform.isMacOS) {
+    if (!kIsWeb && (Platform.isIOS || Platform.isMacOS)) {
       if (await FlutterBluePlus.adapterState.first ==
           BluetoothAdapterState.unknown) {
         await Future.delayed(const Duration(seconds: 1));

--- a/mtrust_urp_ble_strategy/lib/src/ble_strategy.dart
+++ b/mtrust_urp_ble_strategy/lib/src/ble_strategy.dart
@@ -103,7 +103,9 @@ class UrpBleStrategy extends ConnectionStrategy {
     FoundBleDevice? device;
 
     await for (final item in _scanForDevices()) {
-      if (deviceAddress == null || item.address == deviceAddress) {
+      if (deviceAddress == null ||
+          item.address == deviceAddress ||
+          item.name == deviceAddress) {
         device = item;
         break;
       }
@@ -299,7 +301,11 @@ class UrpBleStrategy extends ConnectionStrategy {
       urpLogger.w("Characteristic was null");
       disconnectDevice();
     }
-    _getBatteryCharacteristic();
+    try {
+      await _getBatteryCharacteristic();
+    } catch (e) {
+      urpLogger.w("Battery characteristic not supported: $e");
+    }
   }
 
   /// called when batteryCharacteristic value changes.
@@ -339,7 +345,7 @@ class UrpBleStrategy extends ConnectionStrategy {
     await FlutterBluePlus.stopScan();
   }
 
-  // if continueImmediately is true, the scanning will be stopped
+// if continueImmediately is true, the scanning will be stopped
   // after the first reader is found
   Stream<FoundBleDevice> _scanForDevices() async* {
     List<FoundBleDevice> foundDevices = [];
@@ -364,6 +370,16 @@ class UrpBleStrategy extends ConnectionStrategy {
     final timeout = Duration(seconds: 10);
 
     urpLogger.d("Starting scan");
+
+    // Wait for the adapter to be ready if needed.
+    // This is especially important on iOS/macOS where the service needs longer to initialize.
+    // See FlutterBluePlus documentation for more details.
+    if (Platform.isIOS || Platform.isMacOS) {
+      if (await FlutterBluePlus.adapterState.first ==
+          BluetoothAdapterState.unknown) {
+        await Future.delayed(const Duration(seconds: 1));
+      }
+    }
 
     await FlutterBluePlus.startScan(
       timeout: timeout,

--- a/mtrust_urp_ble_strategy/lib/src/ble_strategy.dart
+++ b/mtrust_urp_ble_strategy/lib/src/ble_strategy.dart
@@ -301,11 +301,6 @@ class UrpBleStrategy extends ConnectionStrategy {
       urpLogger.w("Characteristic was null");
       disconnectDevice();
     }
-    try {
-      await _getBatteryCharacteristic();
-    } catch (e) {
-      urpLogger.w("Battery characteristic not supported: $e");
-    }
   }
 
   /// called when batteryCharacteristic value changes.

--- a/mtrust_urp_ble_strategy/pubspec.yaml
+++ b/mtrust_urp_ble_strategy/pubspec.yaml
@@ -1,5 +1,6 @@
 name: mtrust_urp_ble_strategy
 version: 9.1.0-12
+publish_to: none
 environment: 
   sdk: ^3.5.0
   flutter: '>=1.17.0'
@@ -9,7 +10,8 @@ dependencies:
     sdk: flutter
   freezed_annotation: ^2.0.3
   provider: ^6.0.2
-  mtrust_urp_core: ^9.1.0-12
+  mtrust_urp_core: 
+    path: ../mtrust_urp_core
   flutter_blue_plus: ^1.32.11
   json_annotation: ^4.8.1
   collection: ^1.18.0

--- a/mtrust_urp_core/lib/src/command_wrapper.dart
+++ b/mtrust_urp_core/lib/src/command_wrapper.dart
@@ -5,68 +5,188 @@ import 'package:mtrust_urp_core/src/api_service.dart';
 /// Abstract wrapper for the core commands, these commands need to be wrapped
 /// in a device specific Command Wrapper before they can be send to a device.
 abstract class CmdWrapper extends ChangeNotifier {
-  /// Ping the device.
-  Future<void> ping();
+  /// Adds a core command to the queue.
+  /// Need to be implemented by the specific device wrapper.
+  Future<UrpResponse> addCoreCmdToQueue(UrpCoreCommand command);
 
-  /// Get the device info.
-  Future<UrpDeviceInfo> info();
+  /// Gets the power state of the device.
+  Future<UrpPowerState> getPower() async {
+    final cmd = UrpCoreCommand(
+      command: UrpCommand.urpGetPower,
+    );
+    final res = await addCoreCmdToQueue(cmd);
 
-  /// Get the power state of the device.
-  Future<UrpPowerState> getPower();
+    return UrpPowerState.fromBuffer(res.payload);
+  }
 
-  /// Set the device name.
-  Future<void> setName(String? name);
+  /// Pings the device.
+  Future<void> ping() async {
+    final cmd = UrpCoreCommand(
+      command: UrpCommand.urpPing,
+    );
+    await addCoreCmdToQueue(cmd);
+  }
 
-  /// Get the device name.
-  Future<UrpDeviceName> getName();
+  /// Returns the device info. Throws an error if failed.
+  Future<UrpDeviceInfo> info() async {
+    final cmd = UrpCoreCommand(
+      command: UrpCommand.urpGetInfo,
+    );
+    final res = await addCoreCmdToQueue(cmd);
 
-  /// Pair a device.
-  Future<void> pair();
+    return UrpDeviceInfo.fromBuffer(res.payload);
+  }
 
-  /// Unpair a device.
-  Future<void> unpair();
+  /// Sets the name of the device.
+  Future<void> setName(String? name) async {
+    final cmd = UrpCoreCommand(
+      command: UrpCommand.urpSetName,
+      setNameParameters: UrpSetNameParameters(name: name),
+    );
+    await addCoreCmdToQueue(cmd);
+  }
 
-  /// Start an access point for the firmware update.
-  Future<UrpWifiState> startAP(String ssid, String apk);
+  /// Returns the device name. Throws an error if failed.
+  Future<UrpDeviceName> getName() async {
+    final cmd = UrpCoreCommand(
+      command: UrpCommand.urpGetName,
+    );
+    final res = await addCoreCmdToQueue(cmd);
 
-  /// Stop the access point.
-  Future<void> stopAP();
+    return UrpDeviceName.fromBuffer(res.payload);
+  }
 
-  /// Connect to an access point.
-  Future<UrpWifiState> connectAP(String ssid, String apk);
+  /// Unpair the device.
+  Future<void> unpair() async {
+    final cmd = UrpCoreCommand(
+      command: UrpCommand.urpUnpair,
+    );
+    await addCoreCmdToQueue(cmd);
+  }
 
-  /// Disconnect from an access point.
-  Future<void> disconnectAP();
+  /// Starts the DFU mode of the device.
+  Future<void> startDFU() async {
+    final cmd = UrpCoreCommand(
+      command: UrpCommand.urpStartDfu,
+    );
+    await addCoreCmdToQueue(cmd);
+  }
 
-  /// Start DFU.
-  Future<void> startDFU();
+  /// Start AP. Throws an error if failed.
+  Future<UrpWifiState> startAP(String ssid, String apk) async {
+    final cmd = UrpCoreCommand(
+      command: UrpCommand.urpStartAp,
+      apParameters: UrpApParamters(ssid: ssid, password: apk),
+    );
+    final res = await addCoreCmdToQueue(cmd);
 
-  /// Stop DFU.
-  Future<void> stopDFU();
+    return UrpWifiState.fromBuffer(res.payload);
+  }
 
-  /// Put the device to sleep mode.
-  /// It will disconnect from the device.
-  Future<void> sleep();
+  /// Stop AP.
+  Future<void> stopAP() async {
+    final cmd = UrpCoreCommand(
+      command: UrpCommand.urpStopAp,
+    );
+    await addCoreCmdToQueue(cmd);
+  }
 
-  /// Turn the device off. It will disconnect from the device.
-  Future<void> off();
+  /// Connect AP. Throws an error if failed.
+  Future<UrpWifiState> connectAP(String ssid, String apk) async {
+    final cmd = UrpCoreCommand(
+      command: UrpCommand.urpConnectAp,
+      apParameters: UrpApParamters(ssid: ssid, password: apk),
+    );
+    final res = await addCoreCmdToQueue(cmd);
 
-  /// Reboot the device. It will disconnect from the device.
-  Future<void> reboot();
+    return UrpWifiState.fromBuffer(res.payload);
+  }
 
-  /// Prevent the device from going to sleep mode.
-  Future<void> stayAwake();
+  /// Disconnect AP.
+  Future<void> disconnectAP() async {
+    final cmd = UrpCoreCommand(
+      command: UrpCommand.urpDisconnectAp,
+    );
+    await addCoreCmdToQueue(cmd);
+  }
 
-  /// Get the public key of the device.
-  Future<UrpPublicKey> getPublicKey();
+  /// Stops the DFU mode of the device.
+  Future<void> stopDFU() async {
+    final cmd = UrpCoreCommand(
+      command: UrpCommand.urpStopDfu,
+    );
+    await addCoreCmdToQueue(cmd);
+  }
 
-  /// Get the device id
-  Future<UrpDeviceId> getDeviceId();
+  /// Puts the device to sleep mode. This will disconnect the device.
+  Future<void> sleep() async {
+    final cmd = UrpCoreCommand(
+      command: UrpCommand.urpSleep,
+    );
+    await addCoreCmdToQueue(cmd);
+  }
 
-  /// Identify a reader. Triggers the LED to identify the device.
-  Future<void> identify();
+  /// Turns the device off. This will disconnect the device.
+  Future<void> off() async {
+    final cmd = UrpCoreCommand(
+      command: UrpCommand.urpOff,
+    );
+    await addCoreCmdToQueue(cmd);
+  }
+
+  /// Reboots the device. This will disconnect the device.
+  Future<void> reboot() async {
+    final cmd = UrpCoreCommand(
+      command: UrpCommand.urpReboot,
+    );
+    await addCoreCmdToQueue(cmd);
+  }
+
+  /// Prevents the device from going to sleep mode.
+  Future<void> stayAwake() async {
+    final cmd = UrpCoreCommand(
+      command: UrpCommand.urpStayAwake,
+    );
+    await addCoreCmdToQueue(cmd);
+  }
+
+  /// Returns the public key of the device. Throws an error if failed.
+  Future<UrpPublicKey> getPublicKey() async {
+    final cmd = UrpCoreCommand(
+      command: UrpCommand.urpGetPublicKey,
+    );
+    final res = await addCoreCmdToQueue(cmd);
+    return UrpPublicKey.fromBuffer(res.payload);
+  }
+
+  /// Return the device id. Throws an error if failed.
+  Future<UrpDeviceId> getDeviceId() async {
+    final cmd = UrpCoreCommand(
+      command: UrpCommand.urpGetDeviceId,
+    );
+    final res = await addCoreCmdToQueue(cmd);
+    return UrpDeviceId.fromBuffer(res.payload);
+  }
+
+  /// Identify reader. Triggers the LED to identify the device.
+  Future<void> identify() async {
+    final cmd = UrpCoreCommand(
+      command: UrpCommand.urpIdentify,
+    );
+    await addCoreCmdToQueue(cmd);
+  }
+
+  /// Get the URP types version supported by the device
+  Future<UrpTypesVersion> getVersion() async {
+    final cmd = UrpCoreCommand(
+      command: UrpCommand.urpGetVersion,
+    );
+    final res = await addCoreCmdToQueue(cmd);
+    return UrpTypesVersion.fromBuffer(res.payload);
+  }
 
   /// Fetch new token
+  /// TODO: rephrase this to refreshToken or something similar
   Future<UrpSecureToken> getToken(
     UrpSecureToken oldToken,
     UrpPublicKey publicKey,

--- a/mtrust_urp_core/lib/src/command_wrapper.dart
+++ b/mtrust_urp_core/lib/src/command_wrapper.dart
@@ -186,7 +186,6 @@ abstract class CmdWrapper extends ChangeNotifier {
   }
 
   /// Fetch new token
-  /// TODO: rephrase this to refreshToken or something similar
   Future<UrpSecureToken> getToken(
     UrpSecureToken oldToken,
     UrpPublicKey publicKey,

--- a/mtrust_urp_core/lib/src/connection_strategy.dart
+++ b/mtrust_urp_core/lib/src/connection_strategy.dart
@@ -316,6 +316,8 @@ abstract class ConnectionStrategy extends ChangeNotifier {
 
       // for now only allow messages from readers
       if (message.header.origin.deviceClass != UrpDeviceClass.urpReader) {
+        urpLogger.w(
+            'Ignoring message from unknown origin: ${message.header.origin}');
         return;
       }
 

--- a/mtrust_urp_core/lib/src/connection_strategy.dart
+++ b/mtrust_urp_core/lib/src/connection_strategy.dart
@@ -314,15 +314,13 @@ abstract class ConnectionStrategy extends ChangeNotifier {
     try {
       final message = UrpMessage.fromBuffer(buffer);
 
-      // check if the origin is myself
-      if (message.header.origin.deviceClass == UrpDeviceClass.urpHost) {
-        urpLogger.w(
-          'Received message for different origin: ${message.header.origin}',
-        );
+      // for now only allow messages from readers
+      if (message.header.origin.deviceClass != UrpDeviceClass.urpReader) {
         return;
       }
 
       // handle message
+      // not checking the origin here to keep downward compatibility
       if (message.whichPayload() == UrpMessage_Payload.response) {
         final seq = message.header.seqNr;
 

--- a/mtrust_urp_core/lib/src/connection_strategy.dart
+++ b/mtrust_urp_core/lib/src/connection_strategy.dart
@@ -314,54 +314,50 @@ abstract class ConnectionStrategy extends ChangeNotifier {
     try {
       final message = UrpMessage.fromBuffer(buffer);
 
+      // check if the origin is myself
+      if (message.header.origin.deviceClass == UrpDeviceClass.urpHost) {
+        urpLogger.w(
+          'Received message for different origin: ${message.header.origin}',
+        );
+        return;
+      }
+
       // handle message
-      if (message.whichPayload() == UrpMessage_Payload.request) {
+      if (message.whichPayload() == UrpMessage_Payload.response) {
+        final seq = message.header.seqNr;
+
+        // get attaches cmd to resolve the completer
+        final cmd = _cmdQueue[seq];
+        if (cmd == null) {
+          urpLogger.e('Unknown response from reader $seq');
+          return;
+        }
+
+        // check if cmd was already completed
+        if (cmd.completer.isCompleted) {
+          _cmdQueue.remove(seq);
+          return;
+        }
+
+        // check if device returned an error
+        if (message.header.errorCode != UrpErrorCode.urpNoError) {
+          final deviceError = DeviceError(
+            errorCode: message.header.errorCode,
+            errorMessage: message.header.error,
+          );
+          cmd.completer.completeError(deviceError);
+        } else {
+          // complete the command with the response
+          cmd.completer.complete(message.response);
+        }
+        _cmdQueue.remove(seq);
+      } else if (message.whichPayload() == UrpMessage_Payload.request) {
         if (onRequestCallback != null) {
           onRequestCallback!(message);
         } else {
           urpLogger.w('No callback defined for incoming requests: $message');
         }
-      } else if (message.whichPayload() == UrpMessage_Payload.response) {
-        final seq = message.header.seqNr;
-        final cmd = _cmdQueue[seq];
-
-        if (cmd == null) {
-          urpLogger.e('Unknown seq from reader $seq');
-          return;
-        }
-
-        if (message.header.error.isNotEmpty) {
-          urpLogger.e(
-            'Reader returned error for : '
-            '$message\n',
-          );
-          if (cmd.completer.isCompleted) {
-            _cmdQueue.remove(seq);
-            return;
-          }
-          final deviceError = DeviceError(
-            errorCode: message.header.errorCode.value,
-            errorMessage: message.header.error,
-          );
-          cmd.completer.completeError(deviceError);
-        } else {
-          // final duration = DateTime.now().difference(cmd.created);
-          // urpLogger
-          //   ..d('Processing response for ${cmd.request}')
-          //   ..d(
-          //     'Command took ${duration.inMilliseconds}ms',
-          //   );
-
-          if (cmd.completer.isCompleted) {
-            urpLogger.d('Completer already completed');
-            _cmdQueue.remove(seq);
-            return;
-          }
-
-          cmd.completer.complete(message.response);
-        }
-        _cmdQueue.remove(seq);
-      } else if (message.whichPayload() == UrpMessage_Payload.notSet) {
+      } else {
         urpLogger.log(
           Level.warning,
           'No Payload set in message $message',

--- a/mtrust_urp_core/lib/src/connection_strategy.dart
+++ b/mtrust_urp_core/lib/src/connection_strategy.dart
@@ -59,6 +59,7 @@ abstract class ConnectionStrategy extends ChangeNotifier {
   /// Callback when the device is pinged
   void Function()? pingDeviceCallback;
 
+  /// Callback when a request is received from the device
   void Function(UrpMessage msg)? onRequestCallback;
 
   /// Set callback when the device is connected

--- a/mtrust_urp_core/lib/src/connection_strategy.dart
+++ b/mtrust_urp_core/lib/src/connection_strategy.dart
@@ -59,6 +59,8 @@ abstract class ConnectionStrategy extends ChangeNotifier {
   /// Callback when the device is pinged
   void Function()? pingDeviceCallback;
 
+  void Function(UrpMessage msg)? onRequestCallback;
+
   /// Set callback when the device is connected
   void onConnect(void Function() callback) {
     _setupTimers();
@@ -311,10 +313,15 @@ abstract class ConnectionStrategy extends ChangeNotifier {
     try {
       final message = UrpMessage.fromBuffer(buffer);
 
-      if (message.whichPayload() == UrpMessage_Payload.response) {
-        //securalicLogger.i(message.toDebugString());
+      // handle message
+      if (message.whichPayload() == UrpMessage_Payload.request) {
+        if (onRequestCallback != null) {
+          onRequestCallback!(message);
+        } else {
+          urpLogger.w('No callback defined for incoming requests: $message');
+        }
+      } else if (message.whichPayload() == UrpMessage_Payload.response) {
         final seq = message.header.seqNr;
-
         final cmd = _cmdQueue[seq];
 
         if (cmd == null) {
@@ -324,16 +331,15 @@ abstract class ConnectionStrategy extends ChangeNotifier {
 
         if (message.header.error.isNotEmpty) {
           urpLogger.e(
-            'Reader returned error for ${cmd.request}: '
-            '${message.header.error}\n'
-            'Error Code: ${message.header.errorCode.value}',
+            'Reader returned error for : '
+            '$message\n',
           );
           if (cmd.completer.isCompleted) {
             _cmdQueue.remove(seq);
             return;
           }
           final deviceError = DeviceError(
-            errorCode: message.header.errorCode.value, 
+            errorCode: message.header.errorCode.value,
             errorMessage: message.header.error,
           );
           cmd.completer.completeError(deviceError);

--- a/mtrust_urp_core/lib/src/connection_strategy.dart
+++ b/mtrust_urp_core/lib/src/connection_strategy.dart
@@ -317,7 +317,8 @@ abstract class ConnectionStrategy extends ChangeNotifier {
       // for now only allow messages from readers
       if (message.header.origin.deviceClass != UrpDeviceClass.urpReader) {
         urpLogger.w(
-            'Ignoring message from unknown origin: ${message.header.origin}');
+          'Ignoring message from unknown origin: ${message.header.origin}',
+        );
         return;
       }
 

--- a/mtrust_urp_core/lib/src/exceptions.dart
+++ b/mtrust_urp_core/lib/src/exceptions.dart
@@ -47,16 +47,3 @@ class ApiException extends Error {
     return errorMessage;
   }
 }
-
-class UrpProtocolException extends Error {
-  /// Creates a new instance of [UrpProtocolException]
-  UrpProtocolException(this.message);
-
-  /// The error message
-  final String message;
-
-  @override
-  String toString() {
-    return message;
-  }
-}

--- a/mtrust_urp_core/lib/src/exceptions.dart
+++ b/mtrust_urp_core/lib/src/exceptions.dart
@@ -1,3 +1,5 @@
+import 'package:mtrust_urp_types/wrapper.pb.dart';
+
 /// Thrown when a command is cancelled
 class CommandCancelledException extends Error {}
 
@@ -17,7 +19,7 @@ class DeviceError extends Error {
   });
 
   /// The error code returned by the device
-  final int errorCode;
+  final UrpErrorCode errorCode;
 
   /// The error message returned by the device
   final String errorMessage;

--- a/mtrust_urp_core/lib/src/exceptions.dart
+++ b/mtrust_urp_core/lib/src/exceptions.dart
@@ -10,7 +10,6 @@ class ConnectionStrategyDisposedException extends CommandCancelledException {}
 
 /// Thrown when the device returns an error for a command
 class DeviceError extends Error {
-
   /// Creates a new instance of [DeviceError]
   DeviceError({
     required this.errorCode,
@@ -19,6 +18,7 @@ class DeviceError extends Error {
 
   /// The error code returned by the device
   final int errorCode;
+
   /// The error message returned by the device
   final String errorMessage;
 
@@ -38,6 +38,7 @@ class ApiException extends Error {
 
   /// The error code returned by the API
   final int errorCode;
+
   /// The error message returned by the API
   final String errorMessage;
 
@@ -45,4 +46,17 @@ class ApiException extends Error {
   String toString() {
     return errorMessage;
   }
-} 
+}
+
+class UrpProtocolException extends Error {
+  /// Creates a new instance of [UrpProtocolException]
+  UrpProtocolException(this.message);
+
+  /// The error message
+  final String message;
+
+  @override
+  String toString() {
+    return message;
+  }
+}

--- a/mtrust_urp_core/pubspec.yaml
+++ b/mtrust_urp_core/pubspec.yaml
@@ -12,8 +12,7 @@ dependencies:
   flutter_svg: ^2.0.10+1
   http: ^1.2.2
   logger: ^2.3.0
-  mtrust_urp_types: 
-    path: ../../mtrust-urp-types/packages/urp_types_dart
+  mtrust_urp_types: ^6.2.1
   protobuf: ^3.1.0
   shared_preferences: ^2.3.5
 dev_dependencies: 

--- a/mtrust_urp_core/pubspec.yaml
+++ b/mtrust_urp_core/pubspec.yaml
@@ -1,5 +1,6 @@
 name: mtrust_urp_core
 version: 9.1.0-12
+publish_to: none
 environment: 
   sdk: '>=2.17.0 <4.0.0'
   flutter: '>=1.17.0'
@@ -11,7 +12,8 @@ dependencies:
   flutter_svg: ^2.0.10+1
   http: ^1.2.2
   logger: ^2.3.0
-  mtrust_urp_types: ^6.2.0
+  mtrust_urp_types: 
+    path: ../../mtrust-urp-types/packages/urp_types_dart
   protobuf: ^3.1.0
   shared_preferences: ^2.3.5
 dev_dependencies: 

--- a/mtrust_urp_ui/example/pubspec.yaml
+++ b/mtrust_urp_ui/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: example
 version: 9.1.0-12
+publish_to: none
 environment: 
   sdk: ^3.5.0
   flutter: '>=1.17.0'
@@ -8,9 +9,12 @@ dependencies:
   flutter: 
     sdk: flutter
   liquid_flutter: ^22.0.1
-  mtrust_urp_core: ^9.1.0-12
-  mtrust_urp_ui: ^9.1.0-12
-  mtrust_urp_virtual_strategy: ^9.1.0-12
+  mtrust_urp_core: 
+    path: ../../mtrust_urp_core
+  mtrust_urp_ui: 
+    path: ../../mtrust_urp_ui
+  mtrust_urp_virtual_strategy: 
+    path: ../../mtrust_urp_virtual_strategy
 dev_dependencies: 
   flutter_test: 
     sdk: flutter

--- a/mtrust_urp_ui/pubspec.yaml
+++ b/mtrust_urp_ui/pubspec.yaml
@@ -10,8 +10,7 @@ dependencies:
     sdk: flutter
   flutter_localizations: 
     sdk: flutter
-  mtrust_urp_types: 
-    path: ../../mtrust-urp-types/packages/urp_types_dart
+  mtrust_urp_types: ^6.2.1
   mtrust_urp_core: 
     path: ../mtrust_urp_core
   intl: 0.20.2

--- a/mtrust_urp_ui/pubspec.yaml
+++ b/mtrust_urp_ui/pubspec.yaml
@@ -1,5 +1,6 @@
 name: mtrust_urp_ui
 version: 9.1.0-12
+publish_to: none
 environment: 
   sdk: ^3.5.0
   flutter: '>=1.17.0'
@@ -9,8 +10,10 @@ dependencies:
     sdk: flutter
   flutter_localizations: 
     sdk: flutter
-  mtrust_urp_types: ^6.2.0
-  mtrust_urp_core: ^9.1.0-12
+  mtrust_urp_types: 
+    path: ../../mtrust-urp-types/packages/urp_types_dart
+  mtrust_urp_core: 
+    path: ../mtrust_urp_core
   intl: 0.20.2
   liquid_flutter: ^22.0.4
   shared_preferences: ^2.3.5
@@ -18,7 +21,8 @@ dev_dependencies:
   flutter_test: 
     sdk: flutter
   flutter_lints: ^4.0.0
-  mtrust_urp_virtual_strategy: ^9.1.0-12
+  mtrust_urp_virtual_strategy: 
+    path: ../mtrust_urp_virtual_strategy
   golden_toolkit: ^0.15.0
   mocktail: ^1.0.4
 repository: https://github.com/emdgroup/mtrust-urp

--- a/mtrust_urp_usb_strategy/pubspec.yaml
+++ b/mtrust_urp_usb_strategy/pubspec.yaml
@@ -1,5 +1,6 @@
 name: mtrust_urp_usb_strategy
 version: 9.1.0-12
+publish_to: none
 environment: 
   sdk: '>=2.17.0 <4.0.0'
   flutter: '>=1.17.0'
@@ -7,7 +8,8 @@ description: USB Connection Strategy for URP
 dependencies: 
   flutter: 
     sdk: flutter
-  mtrust_urp_core: ^9.1.0-12
+  mtrust_urp_core: 
+    path: ../mtrust_urp_core
   flutter_libserialport: ^0.4.0
 dev_dependencies: 
   flutter_test: 

--- a/mtrust_urp_virtual_strategy/pubspec.yaml
+++ b/mtrust_urp_virtual_strategy/pubspec.yaml
@@ -1,5 +1,6 @@
 name: mtrust_urp_virtual_strategy
 version: 9.1.0-12
+publish_to: none
 environment: 
   sdk: '>=2.17.0 <4.0.0'
   flutter: '>=1.17.0'
@@ -9,7 +10,8 @@ dependencies:
     sdk: flutter
   freezed_annotation: ^2.0.3
   provider: ^6.0.2
-  mtrust_urp_core: ^9.1.0-12
+  mtrust_urp_core: 
+    path: ../mtrust_urp_core
   json_annotation: ^4.8.1
   collection: ^1.18.0
   async: ^2.11.0

--- a/mtrust_urp_wifi_strategy/pubspec.yaml
+++ b/mtrust_urp_wifi_strategy/pubspec.yaml
@@ -1,5 +1,6 @@
 name: mtrust_urp_wifi_strategy
 version: 9.1.0-12
+publish_to: none
 environment: 
   sdk: '>=2.17.0 <4.0.0'
   flutter: '>=1.17.0'
@@ -8,7 +9,8 @@ dependencies:
   flutter: 
     sdk: flutter
   web_socket_channel: ^2.2.0
-  mtrust_urp_core: ^9.1.0-12
+  mtrust_urp_core: 
+    path: ../mtrust_urp_core
 dev_dependencies: 
   flutter_test: 
     sdk: flutter


### PR DESCRIPTION
# Summary

- refactored `coreCmds`. `coreCmds` are now implemented in core and only `deviceCmds` are implemented in the corresponding kits.
- await battery characteristic and catch error accordingly
- extend `findAndConnectDevice` to allow `deviceSerials` as `deviceAdress` as well besides `mac`.
- add `onRequestCallback` for `BleStrategy` to receive and handle logs from readers.

# Checklist

- [x] You agree with our [CLA](https://gist.githubusercontent.com/emdgroup-admin/16cc45ea4315c2ef29eb9d9afc36fcf5/raw/abb9c91f15278a62b9ac3e66144bcd27fa9485c2/CLA.md)
- [x] Included tests (or is not applicable).
- [x] Updated documentation (or is not applicable).