### PR TITLE
feat(core): port device config + cloud_presence support from Python SDK

### DIFF
--- a/mtrust_urp_core/lib/mtrust_urp_core.dart
+++ b/mtrust_urp_core/lib/mtrust_urp_core.dart
@@ -3,6 +3,7 @@ export 'package:mtrust_urp_types/token.pb.dart';
 export 'package:mtrust_urp_types/wrapper.pb.dart';
 
 export 'src/command_wrapper.dart';
+export 'src/config_api_service.dart';
 export 'src/connection_strategy.dart';
 export 'src/exceptions.dart';
 export 'src/found_device.dart';

--- a/mtrust_urp_core/lib/src/command_wrapper.dart
+++ b/mtrust_urp_core/lib/src/command_wrapper.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 import 'package:mtrust_urp_core/mtrust_urp_core.dart';
 import 'package:mtrust_urp_core/src/api_service.dart';
@@ -191,5 +193,147 @@ abstract class CmdWrapper extends ChangeNotifier {
     UrpPublicKey publicKey,
   ) async {
     return ApiService().requestToken(oldToken, publicKey);
+  }
+
+  // --------------------------------------------------------------------
+  // Device configuration (urpGetConfig / urpSetConfig / urpResetConfig /
+  // urpSignChallenge) — mirrors mtrust_py_sdk's ConfigMixin + OtaMixin.
+  //
+  // Security model:
+  //  - setConfig()/resetConfig() accept a backend-signed config payload;
+  //    the device verifies the backend's signature before applying it.
+  //  - getConfig() returns the device's current config signed by the
+  //    device's own private key, so the caller/backend can verify
+  //    authenticity.
+  //  - signChallenge() asks the device to sign a nonce with its own
+  //    private key, which never leaves the device — this is how the
+  //    device proves its identity to the backend (see [ConfigApiService]).
+  // --------------------------------------------------------------------
+
+  /// Reads the device's current configuration.
+  ///
+  /// Returns the config signed by the device's own private key
+  /// (`UrpConfigResponse` — access `.config` / `.signature`), so the
+  /// caller can verify authenticity against the device's known public key.
+  Future<UrpConfigResponse> getConfig() async {
+    final cmd = UrpCoreCommand(
+      command: UrpCommand.urpGetConfig,
+    );
+    final res = await addCoreCmdToQueue(cmd);
+    return UrpConfigResponse.fromBuffer(res.payload);
+  }
+
+  /// Writes a backend-signed configuration to the device.
+  ///
+  /// [signedConfig] must be obtained from [signAndSetConfig] or directly
+  /// from [ConfigApiService.signConfig] — the device will reject any
+  /// payload not signed by its trusted backend key.
+  Future<UrpConfigResponse> setConfig(
+    UrpSignedConfigPayload signedConfig,
+  ) async {
+    final cmd = UrpCoreCommand(
+      command: UrpCommand.urpSetConfig,
+      configPayload: signedConfig,
+    );
+    final res = await addCoreCmdToQueue(cmd);
+    return UrpConfigResponse.fromBuffer(res.payload);
+  }
+
+  /// Resets the device configuration to factory defaults.
+  ///
+  /// [signedReset] must be a backend-signed payload, same trust model as
+  /// [setConfig].
+  Future<UrpConfigResponse> resetConfig(
+    UrpSignedConfigPayload signedReset,
+  ) async {
+    final cmd = UrpCoreCommand(
+      command: UrpCommand.urpResetConfig,
+      configPayload: signedReset,
+    );
+    final res = await addCoreCmdToQueue(cmd);
+    return UrpConfigResponse.fromBuffer(res.payload);
+  }
+
+  /// Asks the device to sign `SHA-256(nonce + deviceId)` with its own
+  /// RSA-2048 private key. The private key never leaves the device.
+  ///
+  /// Used both to authenticate the device to the config-signing backend
+  /// (via [ConfigApiService.requestChallenge] / [ConfigApiService.signConfig])
+  /// and, with an empty [nonce], to prove key ownership for the initial
+  /// `/challenge` request (signs `SHA-256(deviceId)`).
+  ///
+  /// Returns the raw signature bytes (RSA-2048 PKCS1v15, 256 bytes).
+  ///
+  /// RSA-2048 signing takes several seconds on the ESP32-S3 — pass a
+  /// generous timeout when awaiting this call (the default core command
+  /// timeout of 5s is usually NOT enough; callers typically use ~30s).
+  Future<List<int>> signChallenge(String nonce, String deviceId) async {
+    final cmd = UrpCoreCommand(
+      command: UrpCommand.urpSignChallenge,
+      signChallengeParameters: UrpSignChallengeParameters(
+        nonce: nonce,
+        deviceId: deviceId,
+      ),
+    );
+    final res = await addCoreCmdToQueue(cmd);
+    return UrpSignChallengeResponse.fromBuffer(res.payload).signature;
+  }
+
+  /// High-level helper: sign a config with the backend and apply it to the
+  /// device in one step.
+  ///
+  /// Mirrors `mtrust_py_sdk`'s `ConfigMixin.sign_and_set_config`. Performs:
+  ///
+  ///  1. Sign `deviceId` (UTF-8 bytes) via [signChallenge] with an empty
+  ///     nonce, and call `GET /challenge` to obtain a one-time nonce.
+  ///  2. Sign `nonce + deviceId` via [signChallenge].
+  ///  3. POST the structured [configJson] to
+  ///     `{otaServiceUrl}/device/config/sign?device_id=&nonce=&sig=`.
+  ///  4. Apply the backend-signed result via [setConfig].
+  ///
+  /// The device's private key never leaves the device — the SDK is a pure
+  /// transport layer; identity is proven cryptographically via
+  /// challenge-response.
+  ///
+  /// [configJson] should match the shape of `UrpDeviceConfig` — see
+  /// [ConfigApiService.signConfig] for the full field list.
+  ///
+  /// Throws [ConfigValidationException] if the backend rejects the config
+  /// due to a guardrail violation (HTTP 422).
+  Future<UrpConfigResponse> signAndSetConfig({
+    required Map<String, dynamic> configJson,
+    required String otaServiceUrl,
+    required String deviceId,
+    required String devicePublicKeyPem,
+  }) async {
+    final api = ConfigApiService(otaServiceUrl);
+
+    // Step 1: prove key ownership — sign deviceId with nonce="" (device
+    // signs SHA-256("" + deviceId) = SHA-256(deviceId)), then request the
+    // real challenge nonce.
+    final preSigBytes = await signChallenge('', deviceId);
+    final preSig = base64Encode(preSigBytes);
+
+    final nonce = await api.requestChallenge(
+      deviceId: deviceId,
+      publicKeyPem: devicePublicKeyPem,
+      sig: preSig,
+    );
+
+    // Step 2: sign nonce + deviceId to authenticate the actual config-sign
+    // request.
+    final nonceSigBytes = await signChallenge(nonce, deviceId);
+    final nonceSig = base64Encode(nonceSigBytes);
+
+    // Step 3: backend validates, encodes, and signs the config.
+    final signedConfig = await api.signConfig(
+      deviceId: deviceId,
+      nonce: nonce,
+      sig: nonceSig,
+      configJson: configJson,
+    );
+
+    // Step 4: apply to the device.
+    return setConfig(signedConfig);
   }
 }

--- a/mtrust_urp_core/lib/src/config_api_service.dart
+++ b/mtrust_urp_core/lib/src/config_api_service.dart
@@ -1,0 +1,130 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:mtrust_urp_core/mtrust_urp_core.dart';
+
+/// Service for the device-config signing backend endpoints
+/// (`GET /challenge`, `POST /device/config/sign`).
+///
+/// This is a *device-authenticates-to-service* flow, distinct from
+/// `ApiService`'s device-token exchange: the device proves its identity by
+/// signing a server-issued nonce with its own RSA private key (via
+/// `CmdWrapper.signChallenge`), never exposing the key itself. The backend
+/// then signs the validated config with its own key, and the device
+/// verifies that signature before applying the config
+/// (`CmdWrapper.setConfig`).
+///
+/// Mirrors mtrust_py_sdk's
+/// `ConfigMixin.sign_and_set_config`.
+class ConfigApiService {
+  /// Creates a new instance of [ConfigApiService] pointed at [baseUrl].
+  ///
+  /// An [http.Client] may be injected for testing; defaults to a fresh
+  /// `http.Client` per call otherwise (matching `ApiService`'s style).
+  ConfigApiService(this.baseUrl, {http.Client? client})
+      : _client = client ?? http.Client();
+
+  /// Base URL of the OTA/device-services backend (no trailing slash),
+  /// e.g. `https://mtrust-ota-dev.<region>.azurecontainerapps.io`.
+  final String baseUrl;
+
+  final http.Client _client;
+
+  /// GET `/challenge?device_id=&public_key=&sig=` — request a one-time
+  /// nonce for the device-config signing flow.
+  ///
+  /// [sig] must be the device's signature over `deviceId` (UTF-8 bytes),
+  /// base64-encoded (obtained via `CmdWrapper.signChallenge` with an empty
+  /// nonce — i.e. `signChallenge('', deviceId)`, which signs
+  /// `SHA-256(deviceId)`).
+  Future<String> requestChallenge({
+    required String deviceId,
+    required String publicKeyPem,
+    required String sig,
+  }) async {
+    final uri = Uri.parse('$baseUrl/challenge').replace(
+      queryParameters: {
+        'device_id': deviceId,
+        'public_key': publicKeyPem,
+        'sig': sig,
+      },
+    );
+    final res = await _client.get(uri);
+
+    if (res.statusCode != 200) {
+      urpLogger
+          .e('Challenge request failed with status code ${res.statusCode}');
+      throw ApiException(
+        errorCode: res.statusCode,
+        errorMessage: res.body,
+      );
+    }
+
+    final body = json.decode(res.body) as Map<String, dynamic>;
+    return body['nonce'] as String;
+  }
+
+  /// POST `/device/config/sign?device_id=&nonce=&sig=` — validate, encode,
+  /// and backend-sign a config.
+  ///
+  /// [sig] must be the device's signature over `nonce + deviceId` (UTF-8
+  /// bytes), base64-encoded (obtained via
+  /// `signChallenge(nonce, deviceId)`).
+  ///
+  /// [configJson] is the structured JSON body matching the shape of
+  /// `UrpDeviceConfig` (version, scan, button, auto_update, ble_enabled,
+  /// usb_enabled, wifi_enabled, auto_token_refresh, token_refresh_threshold,
+  /// token_refresh_expiry_margin_s, cloud_presence). Fields omitted use
+  /// backend defaults.
+  ///
+  /// Returns the backend-signed [UrpSignedConfigPayload], ready to pass to
+  /// [CmdWrapper.setConfig] / [CmdWrapper.resetConfig].
+  ///
+  /// Throws [ConfigValidationException] on HTTP 422 (guardrail violation),
+  /// or [ApiException] for any other non-2xx response.
+  Future<UrpSignedConfigPayload> signConfig({
+    required String deviceId,
+    required String nonce,
+    required String sig,
+    required Map<String, dynamic> configJson,
+  }) async {
+    final uri = Uri.parse('$baseUrl/device/config/sign').replace(
+      queryParameters: {
+        'device_id': deviceId,
+        'nonce': nonce,
+        'sig': sig,
+      },
+    );
+    final res = await _client.post(
+      uri,
+      headers: {'Content-Type': 'application/json'},
+      body: json.encode(configJson),
+    );
+
+    if (res.statusCode == 422) {
+      final body = json.decode(res.body) as Map<String, dynamic>;
+      throw ConfigValidationException(
+        code: (body['code'] as String?) ?? 'CFG_ERR_UNKNOWN',
+        message: (body['error'] as String?) ?? 'Config validation failed',
+      );
+    }
+
+    if (res.statusCode != 200) {
+      urpLogger
+          .e('Config sign request failed with status code ${res.statusCode}');
+      throw ApiException(
+        errorCode: res.statusCode,
+        errorMessage: res.body,
+      );
+    }
+
+    final body = json.decode(res.body) as Map<String, dynamic>;
+    final signature = base64Decode(body['signature'] as String);
+    final configBytes = base64Decode(body['config_bytes_b64'] as String);
+
+    return UrpSignedConfigPayload(
+      signature: signature,
+      config: UrpDeviceConfig.fromBuffer(configBytes),
+    );
+  }
+}

--- a/mtrust_urp_core/lib/src/exceptions.dart
+++ b/mtrust_urp_core/lib/src/exceptions.dart
@@ -49,3 +49,28 @@ class ApiException extends Error {
     return errorMessage;
   }
 }
+
+/// Thrown when the backend rejects a device config due to a guardrail
+/// violation (HTTP 422 from `POST /device/config/sign`).
+///
+/// Mirrors the Python SDK's `ConfigValidationError` — carries the backend's
+/// stable machine-readable [code] (e.g. `CFG_ERR_SCAN_TIMEOUT_RANGE`) so
+/// callers can branch on it without parsing [message].
+class ConfigValidationException extends Error {
+  /// Creates a new instance of [ConfigValidationException]
+  ConfigValidationException({
+    required this.code,
+    required this.message,
+  });
+
+  /// Stable machine-readable error code returned by the backend.
+  final String code;
+
+  /// Human-readable error message returned by the backend.
+  final String message;
+
+  @override
+  String toString() {
+    return '$code: $message';
+  }
+}

--- a/mtrust_urp_core/test/command_wrapper_config_test.dart
+++ b/mtrust_urp_core/test/command_wrapper_config_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mtrust_urp_core/mtrust_urp_core.dart';
+
+/// Minimal [CmdWrapper] test double: records the last [UrpCoreCommand] sent
+/// and returns a canned [UrpResponse] (or throws a canned error), bypassing
+/// any real transport. This exercises exactly the request-construction /
+/// response-parsing logic added to [CmdWrapper] for device config support.
+class _FakeCmdWrapper extends CmdWrapper {
+  UrpCoreCommand? lastCommand;
+  UrpResponse Function(UrpCoreCommand command)? onCommand;
+
+  @override
+  Future<UrpResponse> addCoreCmdToQueue(UrpCoreCommand command) async {
+    lastCommand = command;
+    final handler = onCommand;
+    if (handler == null) {
+      throw StateError('onCommand not set');
+    }
+    return handler(command);
+  }
+}
+
+void main() {
+  group('CmdWrapper.getConfig', () {
+    test('sends urpGetConfig and parses UrpConfigResponse', () async {
+      final wrapper = _FakeCmdWrapper();
+      final canned = UrpConfigResponse(
+        signature: List.filled(256, 0x11),
+        config: UrpDeviceConfig(version: 1, cloudPresence: true),
+      );
+      wrapper.onCommand = (_) => UrpResponse(payload: canned.writeToBuffer());
+
+      final result = await wrapper.getConfig();
+
+      expect(wrapper.lastCommand!.command, UrpCommand.urpGetConfig);
+      expect(result.config.version, 1);
+      expect(result.config.cloudPresence, true);
+      expect(result.signature.length, 256);
+    });
+  });
+
+  group('CmdWrapper.setConfig', () {
+    test('sends urpSetConfig with the signed payload attached', () async {
+      final wrapper = _FakeCmdWrapper();
+      final signedConfig = UrpSignedConfigPayload(
+        signature: List.filled(256, 0x22),
+        config: UrpDeviceConfig(version: 1, cloudPresence: true),
+      );
+      final canned = UrpConfigResponse(config: signedConfig.config);
+      wrapper.onCommand = (_) => UrpResponse(payload: canned.writeToBuffer());
+
+      final result = await wrapper.setConfig(signedConfig);
+
+      expect(wrapper.lastCommand!.command, UrpCommand.urpSetConfig);
+      expect(wrapper.lastCommand!.configPayload.config.cloudPresence, true);
+      expect(result.config.cloudPresence, true);
+    });
+  });
+
+  group('CmdWrapper.resetConfig', () {
+    test('sends urpResetConfig with the signed reset payload attached',
+        () async {
+      final wrapper = _FakeCmdWrapper();
+      final signedReset = UrpSignedConfigPayload(
+        signature: List.filled(256, 0x33),
+        config: UrpDeviceConfig(version: 1),
+      );
+      final canned = UrpConfigResponse(config: signedReset.config);
+      wrapper.onCommand = (_) => UrpResponse(payload: canned.writeToBuffer());
+
+      final result = await wrapper.resetConfig(signedReset);
+
+      expect(wrapper.lastCommand!.command, UrpCommand.urpResetConfig);
+      expect(result.config.version, 1);
+    });
+  });
+
+  group('CmdWrapper.signChallenge', () {
+    test('sends urpSignChallenge with nonce/deviceId and returns raw signature',
+        () async {
+      final wrapper = _FakeCmdWrapper();
+      final signature = List.filled(256, 0xAA);
+      wrapper.onCommand = (_) => UrpResponse(
+            payload:
+                UrpSignChallengeResponse(signature: signature).writeToBuffer(),
+          );
+
+      final result = await wrapper.signChallenge('nonce123', 'deviceABC');
+
+      expect(wrapper.lastCommand!.command, UrpCommand.urpSignChallenge);
+      expect(wrapper.lastCommand!.signChallengeParameters.nonce, 'nonce123');
+      expect(
+        wrapper.lastCommand!.signChallengeParameters.deviceId,
+        'deviceABC',
+      );
+      expect(result, signature);
+    });
+
+    test('empty nonce signs SHA-256(deviceId) — nonce param is empty string',
+        () async {
+      final wrapper = _FakeCmdWrapper();
+      wrapper.onCommand = (_) => UrpResponse(
+            payload: UrpSignChallengeResponse(signature: List.filled(256, 0))
+                .writeToBuffer(),
+          );
+
+      await wrapper.signChallenge('', 'deviceABC');
+
+      expect(wrapper.lastCommand!.signChallengeParameters.nonce, '');
+      expect(
+        wrapper.lastCommand!.signChallengeParameters.deviceId,
+        'deviceABC',
+      );
+    });
+  });
+}

--- a/mtrust_urp_core/test/config_api_service_test.dart
+++ b/mtrust_urp_core/test/config_api_service_test.dart
@@ -1,0 +1,148 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mtrust_urp_core/mtrust_urp_core.dart';
+
+void main() {
+  group('ConfigApiService.requestChallenge', () {
+    test('sends device_id/public_key/sig and returns the nonce', () async {
+      Uri? capturedUri;
+
+      final client = MockClient((request) async {
+        capturedUri = request.url;
+        return http.Response(
+          jsonEncode({'nonce': 'abc123', 'expires_in': 120}),
+          200,
+        );
+      });
+
+      final api = ConfigApiService('https://ota.example.com', client: client);
+      final nonce = await api.requestChallenge(
+        deviceId: 'deadbeef',
+        publicKeyPem:
+            '-----BEGIN PUBLIC KEY-----\nAAAA\n-----END PUBLIC KEY-----',
+        sig: 'c2lnbmF0dXJl',
+      );
+
+      expect(nonce, 'abc123');
+      expect(capturedUri!.path, '/challenge');
+      expect(capturedUri!.queryParameters['device_id'], 'deadbeef');
+      expect(capturedUri!.queryParameters['sig'], 'c2lnbmF0dXJl');
+      expect(
+        capturedUri!.queryParameters['public_key'],
+        '-----BEGIN PUBLIC KEY-----\nAAAA\n-----END PUBLIC KEY-----',
+      );
+    });
+
+    test('throws ApiException on non-200 response', () async {
+      final client = MockClient((request) async {
+        return http.Response('{"error": "Device not registered"}', 403);
+      });
+
+      final api = ConfigApiService('https://ota.example.com', client: client);
+
+      expect(
+        () => api.requestChallenge(
+          deviceId: 'deadbeef',
+          publicKeyPem: 'pem',
+          sig: 'sig',
+        ),
+        throwsA(isA<ApiException>()),
+      );
+    });
+  });
+
+  group('ConfigApiService.signConfig', () {
+    test('parses signature and config_bytes_b64 into UrpSignedConfigPayload',
+        () async {
+      // A minimal UrpDeviceConfig{version: 1} encoded: tag=0x08 value=0x01
+      final configBytes = [0x08, 0x01];
+      final configBytesB64 = base64Encode(configBytes);
+      final signatureB64 = base64Encode(List.filled(256, 0xAB));
+
+      Uri? capturedUri;
+      String? capturedBody;
+
+      final client = MockClient((request) async {
+        capturedUri = request.url;
+        capturedBody = request.body;
+        return http.Response(
+          jsonEncode({
+            'signature': signatureB64,
+            'config_bytes_b64': configBytesB64,
+            'config': {'version': 1},
+          }),
+          200,
+        );
+      });
+
+      final api = ConfigApiService('https://ota.example.com', client: client);
+      final result = await api.signConfig(
+        deviceId: 'deadbeef',
+        nonce: 'nonce123',
+        sig: 'sig456',
+        configJson: {'version': 1},
+      );
+
+      expect(capturedUri!.path, '/device/config/sign');
+      expect(capturedUri!.queryParameters['device_id'], 'deadbeef');
+      expect(capturedUri!.queryParameters['nonce'], 'nonce123');
+      expect(capturedUri!.queryParameters['sig'], 'sig456');
+      expect(jsonDecode(capturedBody!), {'version': 1});
+
+      expect(result.config.version, 1);
+      expect(result.signature.length, 256);
+      expect(result.signature, List.filled(256, 0xAB));
+    });
+
+    test('throws ConfigValidationException on 422 with code/error', () async {
+      final client = MockClient((request) async {
+        return http.Response(
+          jsonEncode({
+            'code': 'CFG_ERR_SCAN_TIMEOUT_RANGE',
+            'error': 'scan.timeout_ms must be between 0 and 60000',
+          }),
+          422,
+        );
+      });
+
+      final api = ConfigApiService('https://ota.example.com', client: client);
+
+      try {
+        await api.signConfig(
+          deviceId: 'deadbeef',
+          nonce: 'nonce123',
+          sig: 'sig456',
+          configJson: {
+            'version': 1,
+            'scan': {'timeout_ms': 999999},
+          },
+        );
+        fail('expected ConfigValidationException');
+      } on ConfigValidationException catch (e) {
+        expect(e.code, 'CFG_ERR_SCAN_TIMEOUT_RANGE');
+        expect(e.message, contains('scan.timeout_ms'));
+      }
+    });
+
+    test('throws ApiException on other non-200 responses', () async {
+      final client = MockClient((request) async {
+        return http.Response('Internal Server Error', 500);
+      });
+
+      final api = ConfigApiService('https://ota.example.com', client: client);
+
+      expect(
+        () => api.signConfig(
+          deviceId: 'deadbeef',
+          nonce: 'nonce123',
+          sig: 'sig456',
+          configJson: {'version': 1},
+        ),
+        throwsA(isA<ApiException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Ports `get_config`/`set_config`/`reset_config`/`sign_challenge`/`sign_and_set_config` from `mtrust_py_sdk`'s `ConfigMixin`/`OtaMixin` into `CmdWrapper` — Dart previously had zero device-config support.
- New `ConfigApiService` for the `GET /challenge` + `POST /device/config/sign` backend flow, mirroring `ApiService`'s style. Throws `ConfigValidationException` on HTTP 422 guardrail violations.
- Unblocks toggling `cloud_presence` (REQ-RELAY-01) from Flutter.

## Dependency note
Requires a `cloud_presence` fix in `mtrust-urp-types` (separate repo) — the currently-published Dart protobuf package (`urp_types_dart`) was stuck at `UrpDeviceConfig` field 8, missing fields 9-12 (`auto_token_refresh`, `token_refresh_threshold`, `token_refresh_expiry_margin_s`, `cloud_presence`) entirely, because the canonical `wrapper.proto` never actually got the field added (an earlier commit only hand-patched the generated C++ headers). Fixed at the proto source + regenerated for all languages (Python, C++, Dart, Node, Kotlin) — see `mtrust-urp-types` commit `fix(proto): properly add cloud_presence to canonical wrapper.proto`.

This PR was tested locally against that fixed proto via a `pubspec_overrides.yaml` path override (not committed) pointing at the local `mtrust-urp-types` checkout, since the published pub.dev package (`6.2.1`) predates the fix. Once a new `mtrust_urp_types` version is published with the fix, the `^6.2.1` constraint in `pubspec.yaml` should be bumped accordingly.

## Testing
- 11/11 tests pass: `test/config_api_service_test.dart` (mocked HTTP via `http/testing.dart`'s `MockClient`), `test/command_wrapper_config_test.dart` (fake `CmdWrapper` subclass).
- `dart analyze` clean (2 remaining infos are intentional test-style choices).

## Explicitly out of scope
The relay/WSS transport itself (Dart equivalent of Python's `WsTransport`) is **not** included — `mtrust_urp_wifi_strategy` still only supports plain `ws://`, no port 9001/wss, no relay-capable transport strategy. That's a separate, larger follow-up.